### PR TITLE
Rename gem to iiif-presentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# OSullivan
+# O'Sullivan: A Ruby API for working with IIIF Presentation manifests
 
 [![Build Status](https://travis-ci.org/IIIF/osullivan.svg?branch=development)](https://travis-ci.org/IIIF/osullivan) [![Coverage Status](https://coveralls.io/repos/IIIF/osullivan/badge.svg)](https://coveralls.io/r/IIIF/osullivan)
 
 
 ## Installation
 
-From the source code do `rake install`, or get the latest release [from RubyGems](https://rubygems.org/gems/osullivan).
+From the source code do `rake install`, or get the latest release [from RubyGems](https://rubygems.org/gems/iiif-presentation).
 
 ## Building New Objects
 

--- a/iiif-presentation.gemspec
+++ b/iiif-presentation.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'webmock'
+  spec.add_development_dependency 'multi_json'
   spec.add_development_dependency 'vcr', '~> 2.9.3'
 
   spec.add_dependency 'json'

--- a/iiif-presentation.gemspec
+++ b/iiif-presentation.gemspec
@@ -1,14 +1,14 @@
 version = File.read(File.expand_path('../VERSION', __FILE__)).strip
 
 Gem::Specification.new do |spec|
-  spec.name          = 'osullivan'
+  spec.name          = 'iiif-presentation'
   spec.version       = version
   spec.authors       = ['Jon Stroop']
   spec.email         = ['jpstroop@gmail.com']
   spec.description   = 'API for working with IIIF Presentation manifests.'
   spec.summary       = 'API for working with IIIF Presentation manifests.'
   spec.license       = 'Simplified BSD'
-  spec.homepage      = 'https://github.com/jpstroop/osullivan'
+  spec.homepage      = 'https://github.com/iiif/osullivan'
 
   spec.files         = `git ls-files`.split($/)
   spec.test_files    = spec.files.grep(%r{^spec/})


### PR DESCRIPTION
Tracking down that the 'osullivan' gem contains `IIIF` classes was annoying. I'd like to rename the gem something more conventional, and suggest the github repository could be renamed `iiif-rb` (happy to consider other names).