### PR TITLE
Handle non-array profiles correctly

### DIFF
--- a/lib/iiif/presentation/image_resource.rb
+++ b/lib/iiif/presentation/image_resource.rb
@@ -90,7 +90,7 @@ module IIIF
               if remote_info['profile'].kind_of?(Array)
                 resource.service['profile'] = remote_info['profile'][0]
               else
-                resource.service['profile'] = remote_info['profile'][0]
+                resource.service['profile'] = remote_info['profile']
               end
             else
               resource.service['profile'] = profile


### PR DESCRIPTION
Previously we only used the first character of string profiles.  Now we use the whole string.