### PR TITLE
Few performance optimizations

### DIFF
--- a/lib/iiif/service.rb
+++ b/lib/iiif/service.rb
@@ -234,9 +234,9 @@ module IIIF
     protected
 
     def self.get_descendant_class_by_jld_type(type)
-      IIIF::Service.all_service_subclasses.select { |klass|
+      IIIF::Service.all_service_subclasses.find do |klass|
         klass.const_defined?(:TYPE) && klass.const_get(:TYPE) == type
-      }.first
+      end
     end
 
     # All known subclasses of service.

--- a/lib/iiif/service.rb
+++ b/lib/iiif/service.rb
@@ -1,4 +1,5 @@
 require File.join(File.dirname(__FILE__), 'hash_behaviours')
+require 'active_support/core_ext/class/subclasses'
 require 'active_support/ordered_hash'
 require 'active_support/inflector'
 require 'json'
@@ -240,10 +241,7 @@ module IIIF
 
     # All known subclasses of service.
     def self.all_service_subclasses
-      klass = IIIF::Service
-      # !c.name.nil? filters out classes that rspec creates for some reason;
-      # this condition isn't necessary when using the API, afaik
-      descendants = ObjectSpace.each_object(Class).select { |c| c < klass && !c.name.nil? }
+      @all_service_subclasses ||= IIIF::Service.descendants
     end
 
     def data=(hsh)
@@ -411,8 +409,3 @@ module IIIF
 
   end
 end
-
-
-
-
-


### PR DESCRIPTION
I am looking at implementing O'Sullivan in a Spotlight Resource Indexer and noticed that parsing any sizable manifest (e.g. http://iiif.bodleian.ox.ac.uk/iiif/manifest/eeb272cc-bb48-44b0-9ee3-2cee0338a691.json w/ 1087 canvases) was particularly slow.

I decided to do a quick profile on `IIIF::Service.parse` to see what was going on.  The classes being iterated over the (uncached) `ObjectSpace#each_object` is particularly expensive.  This PR both caches the results of the `IIIF::Service` descendants as well as uses ActiveSupport's subclasses core extension.

Before this PR a call to `IIIF::Service.parse` on the contents of http://iiif.bodleian.ox.ac.uk/iiif/manifest/eeb272cc-bb48-44b0-9ee3-2cee0338a691.json averaged around 26 seconds on my laptop.  After this change the time to parse this manifest is down to a more manageable 5 seconds.